### PR TITLE
Only use cached result if we have read at least once successfully. Fi…

### DIFF
--- a/src/mgos_sht31.c
+++ b/src/mgos_sht31.c
@@ -133,7 +133,8 @@ bool mgos_sht31_read(struct mgos_sht31 *sensor) {
 
   sensor->stats.read++;
 
-  if (start - sensor->stats.last_read_time < MGOS_SHT31_READ_DELAY) {
+  if (sensor->stats.read_success > 0 &&
+      start - sensor->stats.last_read_time < MGOS_SHT31_READ_DELAY) {
     sensor->stats.read_success_cached++;
     return true;
   }


### PR DESCRIPTION
Fixes bug that caused read requests before 2 sec of uptime to return an invalid cached result of 0.0° and 0% RH.
Fixes #4.